### PR TITLE
def:ValueListRef support

### DIFF
--- a/R4DSXML/R/getItemDef.R
+++ b/R4DSXML/R/getItemDef.R
@@ -23,7 +23,9 @@ getItemDef <- function( Nodeset ){
     ID_OriginDescription <- originList[[2]]
       
     #getVal(ItemDefNode4, 'TranslatedText[@xml:lang = "en"]')
-    
+
+    ID_ValueListOID <- getValueListRef(ItemDefNode)
+
     
     df <- data.frame(
         ID_OID,
@@ -37,6 +39,7 @@ getItemDef <- function( Nodeset ){
         ID_CodeListOID,
         ID_OriginType,
         ID_OriginDescription,
+        ID_ValueListOID,
         stringsAsFactors = FALSE
         )
       

--- a/R4DSXML/R/getValueListRef.R
+++ b/R4DSXML/R/getValueListRef.R
@@ -1,0 +1,15 @@
+getValueListRef <- function(Nodeset){
+  namespaces <- namespaces()
+  clfVec <- c()
+  
+  for (i in 1:length(Nodeset)){
+    clf <- getNodeSet(Nodeset[[i]], "./def:ValueListRef", namespaces)
+    
+    if(length(clf) < 1){
+      clfVec <- append(clfVec, NA)
+    }else{
+      clfVec <- append(clfVec, getAttr(Nodeset=clf, Attr="ValueListOID"))
+    }
+  }
+  return(clfVec)
+}


### PR DESCRIPTION
In my project to validate Dataset-XML with Define-XML, I need to obtain contents of def:ValueListRef to support validation of value-level metadata.
The information is necessary to match the variable with corresponding value-level metadata.

Detail:
- Added getValueListRef() to obtain contents in def:ValueListRef.
- Modify getItemDef() to support ID_ValueListOID on getVarMD() result.

cf. 
My project is [Define2Validate](https://github.com/mokjpn/Define2Validate)
